### PR TITLE
Fix spelling mistake snIsRunnging() to snIsRunning()

### DIFF
--- a/src/net/snarl/SnarlNetworkBridge.java
+++ b/src/net/snarl/SnarlNetworkBridge.java
@@ -101,10 +101,10 @@ public class SnarlNetworkBridge {
 			snarlIsRunning = true;
 		} catch (ConnectException e) {
 			snarlIsRunning = false;
-			System.out.println("Snarl is not running");
+			System.err.println("Snarl is not running");
 		} catch (UnknownHostException e) {
 			snarlIsRunning = false;
-			System.out.println("Host not reachable");
+			System.err.println("Host not reachable");
 		} catch (IOException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();

--- a/src/net/snarl/SnarlNetworkBridge.java
+++ b/src/net/snarl/SnarlNetworkBridge.java
@@ -244,7 +244,7 @@ public class SnarlNetworkBridge {
 	 * @return true if Snarl is running and listening to network Connections
 	 *         otherwise false
 	 */
-	public static boolean snIsRunnging() {
+	public static boolean snIsRunning() {
 		return snarlIsRunning;
 	}
 


### PR DESCRIPTION
Changed method `snIsRunnging` to be `snIsRunning`